### PR TITLE
Map file extension changed from *.map to *.css.map

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function (options) {
         sourcemapDestDir = path.dirname(lessFile.path)
       }
 
-      var sourceMapFileName = gutil.replaceExtension(path.basename(lessFile.path), '.map');
+      var sourceMapFileName = gutil.replaceExtension(path.basename(lessFile.path), '.css.map');
       var sourceMapFilePath = path.join(sourcemapDestDir, sourceMapFileName);
 
       // Mixes in default sourcemap generation options


### PR DESCRIPTION
While the original *.map extension technically works, common naming convention is *.css.map. This change reflects that.
